### PR TITLE
Fix crash if "default" profile does not exist

### DIFF
--- a/userInterface/interface_handler.py
+++ b/userInterface/interface_handler.py
@@ -74,7 +74,7 @@ class InterfaceHandler(QDialog):
         self.dlg.comboBoxNamesTarget.clear()
         self.dlg.list_profiles.clear()
         for name in profile_names:
-            # Init source profiles combobox_
+            # Init source profiles combobox
             self.dlg.comboBoxNamesSource.addItem(name)
             if profile in profile_names:
                 self.dlg.comboBoxNamesSource.setCurrentIndex(profile_names.index(profile))

--- a/userInterface/interface_handler.py
+++ b/userInterface/interface_handler.py
@@ -74,9 +74,10 @@ class InterfaceHandler(QDialog):
         self.dlg.comboBoxNamesTarget.clear()
         self.dlg.list_profiles.clear()
         for name in profile_names:
-            # Init source profiles combobox
+            # Init source profiles combobox_
             self.dlg.comboBoxNamesSource.addItem(name)
-            self.dlg.comboBoxNamesSource.setCurrentIndex(profile_names.index(profile))
+            if profile in profile_names:
+                self.dlg.comboBoxNamesSource.setCurrentIndex(profile_names.index(profile))
             # Init target profiles combobox
             self.dlg.comboBoxNamesTarget.addItem(name)
             # Add profiles to list view


### PR DESCRIPTION
This change resolves the error, ensuring that setCurrentIndex is called only if the profile is present in the list of profile names.