### PR TITLE
add(packaging): add QGIS plugin CI necessary tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# CHANGELOG
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+<!--
+
+Unreleased
+
+## version_tag - YYYY-DD-mm
+
+### Added
+
+### Changed
+
+### Removed
+
+-->
+
+## Version 0.5.0-beta1 - 2024-10-04
+
+- add modern plugin's packaging using QGIS Plugin CI
+- apply Python coding rules to whole codebase (PEP8)
+- remove dead code
+- add Git hooks and quality tooling
+- ships the big refactoring started in 2023
+
+## Version 0.4 - 2023-06-29
+
+- Fairly big refactoring and cleanup
+- Better and more verbose error handling
+- Improve performance
+- Reduce backup size, change backup directory
+- Improve dialogs and messages
+- Add support for Vector Tiles connections
+- Fix a crash (thanks Ivano Giuliano!)
+
+## Version 0.31 - 2022-07-31
+
+- Update metadata
+
+## Version 0.3 - 2022-07-13
+
+- Fix scanning for bookmarks, favourites, exp functions, styles
+
+## Version 0.21 - 2022-01-18
+
+- Add support for BSD and other Unixes (thanks Loïc Bartoletti!)
+- Add Italy - German translation (thanks Salvatore Fiandaca!)
+
+## Version 0.2 - 2022-01-12
+
+- First public release

--- a/docs/development/packaging.md
+++ b/docs/development/packaging.md
@@ -1,0 +1,32 @@
+# Packaging and deployment
+
+## Packaging
+
+This plugin is using the [qgis-plugin-ci](https://github.com/opengisch/qgis-plugin-ci/) tool to perform packaging operations.  
+The package command is performing a `git archive` run based on changelog.
+
+Install additional dependencies:
+
+```sh
+python -m pip install -U -r requirements/packaging.txt
+```
+
+```sh
+# package a specific version
+qgis-plugin-ci package 1.3.1
+# package latest version
+qgis-plugin-ci package latest
+```
+
+## Release a version
+
+Everything is done through the continuous deployment:
+
+1. Add the new version to the `CHANGELOG.md`. You can write it manually or use the auto-generated release notes by Github:
+    1. Go to [project's releases](https://github.com/WhereGroup/profile-manager/releases) and click on `Draft a new release`
+    1. In `Choose a tag`, enter the new tag
+    1. Click on `Generate release notes`
+    1. Copy/paste the generated text from `## What's changed` until the line before `**Full changelog**:...` in the CHANGELOG.md replacing `What's changed` with the tag and the publication date
+1. Change the version number in `metadata.txt`
+1. Apply a git tag with the relevant version: `git tag -a 0.3.0 {git commit hash} -m "This version rocks!"`
+1. Push tag to main branch: `git push origin 0.3.0`

--- a/requirements/packaging.txt
+++ b/requirements/packaging.txt
@@ -1,0 +1,4 @@
+# Packaging
+# ---------
+
+qgis-plugin-ci==2.8.*


### PR DESCRIPTION
This PR introduce necessary files to package and release the plugin using [QGIS Plugin CI](https://opengisch.github.io/qgis-plugin-ci/):

- changelog: created using [changes of metadata.txt](https://github.com/WhereGroup/profile-manager/commits/7e7344b7fa7f9f52654e2a38d2f70c816af6d974/metadata.txt?browsing_rename_history=true&new_path=profile_manager/metadata.txt&original_branch=main)
- set the actual version number to 0.5.0-beta1 to comply with Semver
- add documentation page to use it

In a next PR, I'll push a GitHub workflow to automatically package the plugin for every commit on main branch and release it on QGIS official repository.