### PR TITLE
add(ci): GitHub workflow to package plugin on CI/CD

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -1,0 +1,183 @@
+name: "📦 Packaging & 🚀 Release"
+
+env:
+  PROJECT_FOLDER: "profile_manager"
+  PYTHON_VERSION: 3.9
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/packager.yml
+      - requirements/packaging.txt
+      - profile_manager/**/*
+
+# Allow one concurrent deployment per branch/pr
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  translation:
+    name: "💬 i18n compilation"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get source code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install system requirements
+        run: |
+          sudo apt update
+          sudo apt install qt5-qmake qttools5-dev-tools
+          python3 -m pip install -U pyqt5-tools
+
+      - name: Update translations
+        run: pylupdate5 -noobsolete -verbose ${{ env.PROJECT_FOLDER }}/resources/i18n/plugin_translation.pro
+
+      - name: Compile translations
+        run: lrelease ${{ env.PROJECT_FOLDER }}/resources/i18n/*.ts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: translations-build
+          path: ${{ env.PROJECT_FOLDER }}/**/*.qm
+          if-no-files-found: error
+
+  # -- NO TAGS ----------------------------------------------------------------------
+  packaging:
+    name: "📦 Packaging plugin"
+    runs-on: ubuntu-latest
+    needs:
+      - translation
+
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: "requirements/packaging.txt"
+
+      - name: Install project requirements
+        run: |
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U -r requirements/packaging.txt
+
+      - name: Download translations
+        uses: actions/download-artifact@v4
+        with:
+          name: translations-build
+          path: ${{ env.PROJECT_FOLDER }}
+
+      - name: List files
+        run: tree ${{ env.PROJECT_FOLDER }}
+
+      - name: Amend gitignore to include compiled translations and add it to tracked files
+        run: |
+          # include compiled translations
+          sed -i "s|^*.qm.*| |" .gitignore
+
+          # include LICENSE file since it's mandatory
+          cp LICENSE ${{ env.PROJECT_FOLDER }}/
+          sed -i "s|^${{ env.PROJECT_FOLDER }}/LICENSE| |" .gitignore
+
+          # git add full project
+          git add ${{ env.PROJECT_FOLDER }}/
+
+      - name: Package the latest version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          qgis-plugin-ci package latest \
+            --allow-uncommitted-changes \
+            --plugin-repo-url $(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT_FOLDER }}-latest
+          path: |
+            plugins.xml
+            ${{ env.PROJECT_FOLDER }}.*.zip
+          if-no-files-found: error
+
+  # -- ONLY TAGS ----------------------------------------------------------------------
+  release:
+    name: "🚀 Release on tag"
+    runs-on: ubuntu-latest
+    needs:
+      - translation
+
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Get tag name as version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: "requirements/packaging.txt"
+
+      - name: Install project requirements
+        run: |
+          python -m pip install -U pip setuptools wheel
+          python -m pip install -U -r requirements/packaging.txt
+
+      - name: Download translations
+        uses: actions/download-artifact@v4
+        with:
+          name: translations-build
+          path: ${{ env.PROJECT_FOLDER }}
+
+      - name: Amend gitignore to include compiled translations and add it to tracked files
+        run: |
+          # include compiled translations
+          sed -i "s|^*.qm.*| |" .gitignore
+
+          # include LICENSE file since it's mandatory
+          cp LICENSE ${{ env.PROJECT_FOLDER }}/
+          sed -i "s|^${{ env.PROJECT_FOLDER }}/LICENSE| |" .gitignore
+
+          # git add full project
+          git add ${{ env.PROJECT_FOLDER }}/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+      - name: Deploy plugin
+        run: >-
+          qgis-plugin-ci
+          release ${GITHUB_REF/refs\/tags\//}
+          --allow-uncommitted-changes
+          --create-plugin-repo
+          --github-token ${{ secrets.GITHUB_TOKEN }}
+          --osgeo-username ${{ secrets.OSGEO_USER }}
+          --osgeo-password ${{ secrets.OSGEO_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Unreleased
 
 -->
 
-## Version 0.5.0-beta1 - 2024-10-04
+## 0.5.0-beta1 - 2024-10-04
 
 - add modern plugin's packaging using QGIS Plugin CI
 - apply Python coding rules to whole codebase (PEP8)
@@ -24,7 +24,7 @@ Unreleased
 - add Git hooks and quality tooling
 - ships the big refactoring started in 2023
 
-## Version 0.4 - 2023-06-29
+## 0.4 - 2023-06-29
 
 - Fairly big refactoring and cleanup
 - Better and more verbose error handling
@@ -34,19 +34,19 @@ Unreleased
 - Add support for Vector Tiles connections
 - Fix a crash (thanks Ivano Giuliano!)
 
-## Version 0.31 - 2022-07-31
+## 0.31 - 2022-07-31
 
 - Update metadata
 
-## Version 0.3 - 2022-07-13
+## 0.3 - 2022-07-13
 
 - Fix scanning for bookmarks, favourites, exp functions, styles
 
-## Version 0.21 - 2022-01-18
+## 0.21 - 2022-01-18
 
 - Add support for BSD and other Unixes (thanks Loïc Bartoletti!)
 - Add Italy - German translation (thanks Salvatore Fiandaca!)
 
-## Version 0.2 - 2022-01-12
+## 0.2 - 2022-01-12
 
 - First public release

--- a/profile_manager/metadata.txt
+++ b/profile_manager/metadata.txt
@@ -1,41 +1,26 @@
 [general]
 name=Profile Manager
-qgisMinimumVersion=3.12
 description=Makes handling profiles easy by giving you an UI to easily import settings from one profile to another
 about=A QGIS Plugin that provides an UI to easily manage your profiles and import various settings from one profile to another
-version=0.4
-author=WhereGroup GmbH
-email=info@wheregroup.com
-repository=https://github.com/WhereGroup/profile-manager/
-# End of mandatory metadata
-
-homepage=https://wheregroup.com/
 category=Plugins
 tags=profilemanager, manager, profiles, python
 icon=icon.png
+
+# credits and contact
+author=WhereGroup GmbH
+email=info@wheregroup.com
+homepage=https://wheregroup.com/
+repository=https://github.com/WhereGroup/profile-manager/
 tracker=https://github.com/WhereGroup/profile-manager/issues
 
+# QGIS extensions manager flags
 deprecated=False
 experimental=True
 hasProcessingProvider=no
+qgisMinimumVersion=3.12
+qgisMaximumVersion=3.99
 server=False
 
+# versioning
+version=0.5.0-beta1
 changelog=
-    Version 0.4:
-    - Fairly big refactoring and cleanup
-    - Better and more verbose error handling
-    - Improve performance
-    - Reduce backup size, change backup directory
-    - Improve dialogs and messages
-    - Add support for Vector Tiles connections
-    - Fix a crash (thanks Ivano Giuliano!)
-    - ...
-    Version 0.31:
-    - Update metadata
-    Version 0.3:
-    - Fix scanning for bookmarks, favourites, exp functions, styles
-    Version 0.21:
-    - Add support for BSD and other Unixes (thanks Loïc Bartoletti!)
-    - Add Italy - German translation (thanks Salvatore Fiandaca!)
-    Version 0.2:
-    - First public release


### PR DESCRIPTION
To be merged after https://github.com/WhereGroup/profile-manager/pull/21

In this PR, a GitHub workflow to:

- package the plugin on every PR where plugin's files have been modified
- release it as GitHub Release
- publish it automatically to official QGIS repository (see below)


@kannes to make the workflow work, you have to set your plugins.qgis.org credentials as GitHub Actions Secrets (`OSGEO_PASSWORD` and `OSGEO_USER`). Screenshot from [QTribu](https://github.com/geotribu/qtribu):

![image](https://github.com/user-attachments/assets/160846da-86c6-4bbe-9fa6-2970cdef6501)
 
----

- Related to https://github.com/WhereGroup/profile-manager/issues/10
- :heart: Funded by [Oslandia](https://oslandia.com/) and [ANFSI](https://www.linkedin.com/company/anfsi/about/).