### PR TITLE
add(ci): autolabeler for PR and releases

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,34 @@
+ci-cd:
+  - changed-files:
+      - any-glob-to-any-file: .github/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - requirements/*.txt
+          - requirements.txt
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - requirements/documentation.txt
+
+enhancement:
+  - head-branch: ["^feature", "feature", "^improve", "improve"]
+
+packaging:
+  - head-branch: ["^packaging", "packaging"]
+
+tooling:
+  - head-branch: ["^tooling", "tooling"]
+  - changed-files:
+      - any-glob-to-any-file:
+          - .pre-commit-config.yaml
+
+UI:
+  - head-branch: ["^ui", "ui"]
+  - changed-files:
+      - any-glob-to-any-file:
+          - profile_manager/**/*.ui
+          - profile_manager/gui/**

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci
+  categories:
+    - title: Bugs fixes 🐛
+      labels:
+        - bug
+    - title: Features and enhancements 🎉
+      labels:
+        - enhancement
+        - UI
+    - title: Tooling 🔧
+      labels:
+        - ci-cd
+    - title: Documentation 📖
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,14 @@
+name: "🏷 PR Labeler"
+on:
+  - pull_request
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
In this PR:

- a workflow and its related configuration to auto-label PR based on certain branch or commit names (see https://github.com/actions/labeler)
- a workflow to use the PR labels to prettify the auto-generated releases notes introduced in https://github.com/WhereGroup/profile-manager/pull/22

@kannes once merged, would you accept to manually label past PR please? I've not enough rights on the repo.

----

- Related to https://github.com/WhereGroup/profile-manager/issues/10
- :heart: Funded by [Oslandia](https://oslandia.com/) and [ANFSI](https://www.linkedin.com/company/anfsi/about/).