### PR TITLE
update(ci): rm deprecated `set-output` command

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -130,10 +130,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-      - name: Get tag name as version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/