### PR TITLE
Switch dialog tabs to back sensible defaults

### DIFF
--- a/profile_manager/profile_manager_dialog_base.ui
+++ b/profile_manager/profile_manager_dialog_base.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_profiles">
       <attribute name="title">
@@ -193,7 +193,7 @@
        <item>
         <widget class="QTabWidget" name="tabWidget_2">
          <property name="currentIndex">
-          <number>2</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="tab_inner_datasources">
           <attribute name="title">


### PR DESCRIPTION
The tab order was messed up (been there, done that, _several_ times :D ) so that when initially launching the ODT tab was shown instead of the first tab, and on the import tab the "other" child tab instead of the one for the data sources.

This is a quick fix of that.