### PR TITLE
Update maximum QGIS version in metadata for QGIS 4

### DIFF
--- a/profile_manager/metadata.txt
+++ b/profile_manager/metadata.txt
@@ -18,7 +18,7 @@ deprecated=False
 experimental=False
 hasProcessingProvider=no
 qgisMinimumVersion=3.28
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
 server=False
 supportsQt6=True
 


### PR DESCRIPTION
Since we specified a maximum version, we should bump that!