### PR TITLE
remove(packaging): supportsQt6 flag is not a supported flag anymore in metadata.txt

### DIFF
--- a/profile_manager/metadata.txt
+++ b/profile_manager/metadata.txt
@@ -20,7 +20,6 @@ hasProcessingProvider=no
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 server=False
-supportsQt6=True
 
 # versioning - automatically updated by qgis-plugin-ci during packaging and release process
 version=0.8.0-DEV


### PR DESCRIPTION
See: https://github.com/qgis/QGIS-Plugins-Website/pull/250

----

Funded by [Oslandia](https://oslandia.com)

<!-- osl:grant-oss-2026 -->